### PR TITLE
Use `File.lstat/1` for symlink checks

### DIFF
--- a/lib/secret_vault/config.ex
+++ b/lib/secret_vault/config.ex
@@ -247,7 +247,7 @@ defmodule SecretVault.Config do
   end
 
   defp check_priv(%__MODULE__{priv_path: priv} = config) do
-    with {:ok, %File.Stat{links: links}} when links <= 2 <- File.stat(priv) do
+    with {:ok, %File.Stat{type: type}} when type != :symlink <- File.lstat(priv) do
       IO.warn("""
       It looks like `priv` directory is inside `_build`. and it is not linked to `priv` in root
       of your project. If you have called this task while `_build` path is not present, it's okay.


### PR DESCRIPTION
I discovered a bug where the project generates warnings even when the `priv` directory is a symlink. I attempted to resolve it by deleting the `_build` directory, but that didn't help. I've made a change to address this issue, and now everything is functioning correctly. I believe this change also improves the clarity of the check.